### PR TITLE
fix: xprop errors when no wm

### DIFF
--- a/cafe
+++ b/cafe
@@ -25,7 +25,7 @@ has() {
 # awk -F: "NR==2{print $1}" /etc/os-release | sed -E 's/PRETTY_NAME=//' | sed -E 's/["",]//g'
 os=$(sed -n "s/PRETTY_NAME=//p" /etc/os-release | tr -d '"')
 kernel_ver=$(uname -r)
-wm=${WAYLAND_DISPLAY:-$(xprop -id "$(xprop -root _NET_SUPPORTING_WM_CHECK | cut -d' ' -f5)" _NET_WM_NAME | cut -d'"' -f2)}
+wm=${WAYLAND_DISPLAY:-$(xprop -id "$(xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null | cut -d' ' -f5)" _NET_WM_NAME 2>/dev/null | cut -d'"' -f2)}
 [ -z $wm ] && wm="none"
 uptime=$(uptime -p | sed "s/up[[:space:]]//g")
 user=$(id -u -n) # Instead using $USER variable which can be overwrite


### PR DESCRIPTION
This removes the errors displayed by xprop when you don't have any window manager enabled on your linux system. This is done by adding 2>/dev/null at the end of each xprop command.

Tested on: Debian 11 (Bullseye) amd64

*with the wm enabled:*
![with the wm enabled](https://user-images.githubusercontent.com/82547281/204139276-20ac7992-aed0-415c-ad98-9316514a4e69.png)

*without the wm enabled (tty):*
![without wm enabled (cli)](https://user-images.githubusercontent.com/82547281/204139281-33aed14b-eea4-4a68-a1e2-c33991ec48ff.png)

